### PR TITLE
Bugfix about simple_lead_out.cpp

### DIFF
--- a/orne_box_recovery_behavior/src/simple_lead_out.cpp
+++ b/orne_box_recovery_behavior/src/simple_lead_out.cpp
@@ -30,8 +30,8 @@ void SimpleLeadOut::initialize(std::string name, tf2_ros::Buffer* tf, costmap_2d
       width_min_>footprint.points.at(i).y?width_min_=footprint.points.at(i).y:width_min_=width_min_;
     }
 
-    private_nh_.param("base_frame_id", base_frame_id_, std::string("/base_link"));
-    private_nh_.param("scan_frame_id", scan_frame_id_, std::string("/scan"));
+    private_nh_.param("base_frame_id", base_frame_id_, std::string("base_link"));
+    private_nh_.param("scan_frame_id", scan_frame_id_, std::string("scan"));
 
     ros::NodeHandle private_nh_("~/" + name);
     std::string planner_namespace;


### PR DESCRIPTION
リカバリー時に以下のエラーが発生していた．
tf2に対応できていなかったようなので，修正した．

```
[ WARN] [1627494237.610607116, 162.598000000]: Lead out behavior start
Warning: Invalid argument "/base_link" passed to canTransform argument source_frame in tf2 frame_ids cannot start with a '/' like: 
         at line 134 in /tmp/binarydeb/ros-melodic-tf2-0.6.5/src/buffer_core.cpp
```