### PR TITLE
emclをlaunchファイルに追加

### DIFF
--- a/orne_box_navigation_executor/launch/localization.launch
+++ b/orne_box_navigation_executor/launch/localization.launch
@@ -4,12 +4,29 @@
   <arg name="robot_name"    default="alpha"/>
   <arg name="map_file"      default="$(find orne_box_navigation_executor)/maps/mymap"/>
   <arg name="init_pos_file" default="$(find orne_box_navigation_executor)/initial_pose_cfg/initial_pose.yaml"/>
+  <arg name="scan_topic"    default="scan"/>
+  <arg name="emcl"          default="false"/>
 
   <node name="map_server" pkg="map_server" type="map_server" args="$(arg map_file).yaml"/>
 
-  <node pkg="amcl" type="amcl" name="amcl" output="screen">
-    <rosparam file="$(find orne_box_navigation_executor)/param/localization_params.yaml" command="load"/>
-    <rosparam file="$(find orne_box_navigation_executor)/param/localization_params_$(arg robot_name).yaml" command="load"/>
-    <rosparam file="$(arg init_pos_file)" command="load"/>
-  </node>
+  <!-- AMCL -->
+  <group unless="$(arg emcl)">
+    <node pkg="amcl" type="amcl" name="amcl" output="screen">
+      <remap from="scan" to="$(arg scan_topic)"/>
+      <rosparam file="$(find orne_box_navigation_executor)/param/localization_params.yaml" command="load"/>
+      <rosparam file="$(find orne_box_navigation_executor)/param/localization_params_$(arg robot_name).yaml" command="load"/>
+      <rosparam file="$(arg init_pos_file)" command="load"/>
+    </node>
+  </group>
+
+  <!-- EMCL -->
+  <group if="$(arg emcl)">
+    <node pkg="emcl" type="emcl_node" name="emcl_node" output="screen">
+      <remap from="scan" to="$(arg scan_topic)"/>
+      <rosparam file="$(find orne_box_navigation_executor)/param/emcl_params.yaml" command="load"/>
+      <rosparam file="$(find orne_box_navigation_executor)/param/emcl_params_$(arg robot_name).yaml" command="load"/>
+      <rosparam file="$(arg init_pos_file)" command="load"/>
+    </node>
+  </group>
+
 </launch>

--- a/orne_box_navigation_executor/launch/localization.launch
+++ b/orne_box_navigation_executor/launch/localization.launch
@@ -4,7 +4,6 @@
   <arg name="robot_name"    default="alpha"/>
   <arg name="map_file"      default="$(find orne_box_navigation_executor)/maps/mymap"/>
   <arg name="init_pos_file" default="$(find orne_box_navigation_executor)/initial_pose_cfg/initial_pose.yaml"/>
-  <arg name="scan_topic"    default="scan"/>
   <arg name="emcl"          default="false"/>
 
   <node name="map_server" pkg="map_server" type="map_server" args="$(arg map_file).yaml"/>
@@ -12,7 +11,6 @@
   <!-- AMCL -->
   <group unless="$(arg emcl)">
     <node pkg="amcl" type="amcl" name="amcl" output="screen">
-      <remap from="scan" to="$(arg scan_topic)"/>
       <rosparam file="$(find orne_box_navigation_executor)/param/localization_params.yaml" command="load"/>
       <rosparam file="$(find orne_box_navigation_executor)/param/localization_params_$(arg robot_name).yaml" command="load"/>
       <rosparam file="$(arg init_pos_file)" command="load"/>
@@ -22,7 +20,6 @@
   <!-- EMCL -->
   <group if="$(arg emcl)">
     <node pkg="emcl" type="emcl_node" name="emcl_node" output="screen">
-      <remap from="scan" to="$(arg scan_topic)"/>
       <rosparam file="$(find orne_box_navigation_executor)/param/emcl_params.yaml" command="load"/>
       <rosparam file="$(arg init_pos_file)" command="load"/>
     </node>

--- a/orne_box_navigation_executor/launch/nav_static_map.launch
+++ b/orne_box_navigation_executor/launch/nav_static_map.launch
@@ -6,7 +6,7 @@
   <arg name="init_pos_file" default="$(find orne_box_navigation_executor)/initial_pose_cfg/initial_pose.yaml"/>
   <arg name="odom_topic" default="combined_odom"/>
   <arg name="scan_topic"    default="scan"/>
-  <arg name="emcl"          default="true"/>
+  <arg name="emcl"          default="false"/>
 
   <include file="$(find orne_box_navigation_executor)/launch/move_base.launch">
     <arg name="robot_name" value="$(arg robot_name)"/>

--- a/orne_box_navigation_executor/launch/nav_static_map.launch
+++ b/orne_box_navigation_executor/launch/nav_static_map.launch
@@ -1,26 +1,24 @@
 <?xml version="1.0"?>
 
 <launch>
-  <arg name="robot_name"    default="box"/>
-  <arg name="map_file"      default="$(find orne_box_navigation_executor)/maps/mymap"/>
+  <arg name="robot_name" default="box"/>
+  <arg name="map_file"   default="$(find orne_box_navigation_executor)/maps/mymap"/>
   <arg name="init_pos_file" default="$(find orne_box_navigation_executor)/initial_pose_cfg/initial_pose.yaml"/>
-  <arg name="odom_topic"    default="combined_odom"/>
-  <arg name="scan_topic"    default="scan"/>
-  <arg name="emcl"          default="false"/>
+  <arg name="odom_topic" default="combined_odom"/>
+  <arg name="emcl" default="false"/>
 
   <include file="$(find orne_box_navigation_executor)/launch/move_base.launch">
     <arg name="robot_name" value="$(arg robot_name)"/>
-    <arg name="map_file"   value="$(arg map_file)"/>
+    <arg name="map_file" value="$(arg map_file)"/>
     <arg name="odom_topic" value="$(arg odom_topic)"/>
-    <arg name="cmd_vel"    value="icart_mini/cmd_vel"/>
+    <arg name="cmd_vel" value="icart_mini/cmd_vel"/>
   </include>
 
   <include file="$(find orne_box_navigation_executor)/launch/localization.launch">
-    <arg name="robot_name"    value="$(arg robot_name)"/>
-    <arg name="map_file"      value="$(arg map_file)"/>
+    <arg name="robot_name" value="$(arg robot_name)"/>
+    <arg name="map_file" value="$(arg map_file)"/>
     <arg name="init_pos_file" value="$(arg init_pos_file)"/>
-    <arg name="scan_topic"    value="$(arg scan_topic)"/>
-    <arg name="emcl"          value="$(arg emcl)"/>
+    <arg name="emcl" value="$(arg emcl)"/>
   </include>
 
   <node pkg="rviz" type="rviz" name="rviz" args="-d $(find orne_box_navigation_executor)/rviz_cfg/nav.rviz"/>

--- a/orne_box_navigation_executor/launch/nav_static_map.launch
+++ b/orne_box_navigation_executor/launch/nav_static_map.launch
@@ -5,6 +5,8 @@
   <arg name="map_file"   default="$(find orne_box_navigation_executor)/maps/mymap"/>
   <arg name="init_pos_file" default="$(find orne_box_navigation_executor)/initial_pose_cfg/initial_pose.yaml"/>
   <arg name="odom_topic" default="combined_odom"/>
+  <arg name="scan_topic"    default="scan"/>
+  <arg name="emcl"          default="true"/>
 
   <include file="$(find orne_box_navigation_executor)/launch/move_base.launch">
     <arg name="robot_name" value="$(arg robot_name)"/>
@@ -17,6 +19,8 @@
     <arg name="robot_name" value="$(arg robot_name)"/>
     <arg name="map_file" value="$(arg map_file)"/>
     <arg name="init_pos_file" value="$(arg init_pos_file)"/>
+    <arg name="scan_topic"    value="$(arg scan_topic)"/>
+    <arg name="emcl"          value="$(arg emcl)"/>
   </include>
 
   <node pkg="rviz" type="rviz" name="rviz" args="-d $(find orne_box_navigation_executor)/rviz_cfg/nav.rviz"/>

--- a/orne_box_navigation_executor/launch/play_waypoints_nav_box.launch
+++ b/orne_box_navigation_executor/launch/play_waypoints_nav_box.launch
@@ -5,10 +5,9 @@
   <arg name="map_file"       default="$(find orne_box_navigation_executor)/maps/mymap"/>
   <arg name="init_pos_file"  default="$(find orne_box_navigation_executor)/initial_pose_cfg/initial_pose.yaml"/>
   <arg name="waypoints_file" default="$(find orne_box_navigation_executor)/waypoints_cfg/waypoints.yaml"/>
-  <arg name="scan_topic"     default="scan"/>
   <arg name="emcl"           default="false"/>
-  <arg name="suspend"        default="False"/>
 
+  <arg name="suspend" default="False"/>
   <param name="state" value="$(arg suspend)"/>
   <arg name="suspend_file" default="$(find orne_box_strategy)/suspend_cfg/suspend.yaml"/>
   <include file="$(find orne_box_navigation_executor)/launch/play_waypoints_nav_common.launch">
@@ -16,7 +15,6 @@
     <arg name="map_file"       value="$(arg map_file)"/>
     <arg name="init_pos_file"  value="$(arg init_pos_file)"/>
     <arg name="waypoints_file" value="$(arg waypoints_file)"/>
-    <arg name="scan_topic"     value="$(arg scan_topic)"/>
     <arg name="emcl"           value="$(arg emcl)"/>
     <arg name="suspend_file"   value="$(arg suspend_file)"/>
 

--- a/orne_box_navigation_executor/launch/play_waypoints_nav_common.launch
+++ b/orne_box_navigation_executor/launch/play_waypoints_nav_common.launch
@@ -3,18 +3,16 @@
 <launch>
   <arg name="robot_name"     default="box"/>
   <arg name="map_file"       default="$(find orne_box_navigation_executor)/maps/mymap"/>
-  <arg name="init_pos_file"  default="$(find orne_box_navigation_executor)/initial_pose_cfg/initial_pose.yaml"/>
+  <arg name="init_pos_file"  default="$(find orne_box_navigation_executor)/initial_pose_cfg/initial_pose_$(arg robot_name).yaml"/>
   <arg name="waypoints_file" default="$(find orne_box_navigation_executor)/waypoints_cfg/waypoints_$(arg robot_name).yaml"/>
   <arg name="dist_err"       default="0.8"/>
   <arg name="suspend_file"   default="$(find orne_box_strategy)/suspend_cfg/suspend.yaml"/>
-  <arg name="scan_topic"     default="scan"/>
   <arg name="emcl"           default="false"/>
 
   <include file="$(find orne_box_navigation_executor)/launch/nav_static_map.launch">
     <arg name="robot_name"    value="$(arg robot_name)"/>
     <arg name="map_file"      value="$(arg map_file)"/>
     <arg name="init_pos_file" value="$(arg init_pos_file)"/>
-    <arg name="scan_topic"    value="$(arg scan_topic)"/>
     <arg name="emcl"          value="$(arg emcl)"/>
   </include>
 
@@ -24,6 +22,6 @@
   </node>
 
   <node name="tsukuba_challenge_strategy" pkg="orne_box_strategy" type="tsukuba_challenge.py" output="screen">
-    <param name="filename" value="$(arg suspend_file)"/>
+    <param name="filename"      value="$(arg suspend_file)"/>
   </node>
 </launch>

--- a/orne_box_navigation_executor/param/emcl_params.yaml
+++ b/orne_box_navigation_executor/param/emcl_params.yaml
@@ -1,0 +1,33 @@
+odom_freq:                    20
+num_particles:                500
+
+odom_frame_id:                odom
+footprint_frame_id:           base_link
+base_frame_id:                base_link
+scan_frame_id:                hokuyo_link
+
+initial_pose_x:               0.0
+initial_pose_y:               0.0
+initial_pose_a:               0.0
+
+odom_fw_dev_per_fw:           0.19
+odom_fw_dev_per_rot:          0.0001
+odom_rot_dev_per_fw:          0.13
+odom_rot_dev_per_rot:         0.2
+
+laser_likelihood_max_dist:    0.2
+
+alpha_threshold:              0.6
+open_space_threshold:         0.05
+
+expansion_radius_position:    0.1
+expansion_radius_orientation: 0.2
+
+laser_min_range:              0.0
+laser_max_range:              100000000.0
+
+scan_increment:               1
+
+#transform_tolerance:         0.5
+#gui_publish_rate:            50.0
+#laser_max_beams:             180

--- a/orne_box_navigation_executor/param/emcl_params_box.yaml
+++ b/orne_box_navigation_executor/param/emcl_params_box.yaml
@@ -1,0 +1,1 @@
+invert_lidar: true

--- a/orne_box_pkgs.install
+++ b/orne_box_pkgs.install
@@ -26,4 +26,8 @@
     uri: https://github.com/open-rdc/adi_driver
     local-name: adi_driver
     version: master
+- git:
+    uri: https://github.com/open-rdc/emcl.git
+    local-name: emcl
+    version: invert_lidar
 


### PR DESCRIPTION
emclとamclをlaunchファイルで切り替えられるようにした。
デフォルトではamclが起動するようにした。
なお、orne-boxはLiDARが反転して取り付けられているため、以下のブランチで対応させて使用した。
https://github.com/taishiyamamoto/emcl

動作確認の様子
https://youtu.be/NDYCqzlySms

実行したコマンド
```
roslaunch orne_box_bringup orne_box_sim.launch
roslaunch orne_box_navigation_executor play_waypoints_nav_box.launch 
```