### PR TITLE
modify for emcl

### DIFF
--- a/orne_box_navigation_executor/launch/localization.launch
+++ b/orne_box_navigation_executor/launch/localization.launch
@@ -24,7 +24,6 @@
     <node pkg="emcl" type="emcl_node" name="emcl_node" output="screen">
       <remap from="scan" to="$(arg scan_topic)"/>
       <rosparam file="$(find orne_box_navigation_executor)/param/emcl_params.yaml" command="load"/>
-      <rosparam file="$(find orne_box_navigation_executor)/param/emcl_params_$(arg robot_name).yaml" command="load"/>
       <rosparam file="$(arg init_pos_file)" command="load"/>
     </node>
   </group>

--- a/orne_box_navigation_executor/launch/nav_static_map.launch
+++ b/orne_box_navigation_executor/launch/nav_static_map.launch
@@ -1,23 +1,23 @@
 <?xml version="1.0"?>
 
 <launch>
-  <arg name="robot_name" default="alpha"/>
-  <arg name="map_file"   default="$(find orne_box_navigation_executor)/maps/mymap"/>
+  <arg name="robot_name"    default="box"/>
+  <arg name="map_file"      default="$(find orne_box_navigation_executor)/maps/mymap"/>
   <arg name="init_pos_file" default="$(find orne_box_navigation_executor)/initial_pose_cfg/initial_pose.yaml"/>
-  <arg name="odom_topic" default="combined_odom"/>
+  <arg name="odom_topic"    default="combined_odom"/>
   <arg name="scan_topic"    default="scan"/>
   <arg name="emcl"          default="false"/>
 
   <include file="$(find orne_box_navigation_executor)/launch/move_base.launch">
     <arg name="robot_name" value="$(arg robot_name)"/>
-    <arg name="map_file" value="$(arg map_file)"/>
+    <arg name="map_file"   value="$(arg map_file)"/>
     <arg name="odom_topic" value="$(arg odom_topic)"/>
-    <arg name="cmd_vel" value="icart_mini/cmd_vel"/>
+    <arg name="cmd_vel"    value="icart_mini/cmd_vel"/>
   </include>
 
   <include file="$(find orne_box_navigation_executor)/launch/localization.launch">
-    <arg name="robot_name" value="$(arg robot_name)"/>
-    <arg name="map_file" value="$(arg map_file)"/>
+    <arg name="robot_name"    value="$(arg robot_name)"/>
+    <arg name="map_file"      value="$(arg map_file)"/>
     <arg name="init_pos_file" value="$(arg init_pos_file)"/>
     <arg name="scan_topic"    value="$(arg scan_topic)"/>
     <arg name="emcl"          value="$(arg emcl)"/>

--- a/orne_box_navigation_executor/launch/play_waypoints_nav_box.launch
+++ b/orne_box_navigation_executor/launch/play_waypoints_nav_box.launch
@@ -5,8 +5,10 @@
   <arg name="map_file"       default="$(find orne_box_navigation_executor)/maps/mymap"/>
   <arg name="init_pos_file"  default="$(find orne_box_navigation_executor)/initial_pose_cfg/initial_pose.yaml"/>
   <arg name="waypoints_file" default="$(find orne_box_navigation_executor)/waypoints_cfg/waypoints.yaml"/>
+  <arg name="scan_topic"     default="scan"/>
+  <arg name="emcl"           default="false"/>
+  <arg name="suspend"        default="False"/>
 
-  <arg name="suspend" default="False"/>
   <param name="state" value="$(arg suspend)"/>
   <arg name="suspend_file" default="$(find orne_box_strategy)/suspend_cfg/suspend.yaml"/>
   <include file="$(find orne_box_navigation_executor)/launch/play_waypoints_nav_common.launch">
@@ -14,6 +16,8 @@
     <arg name="map_file"       value="$(arg map_file)"/>
     <arg name="init_pos_file"  value="$(arg init_pos_file)"/>
     <arg name="waypoints_file" value="$(arg waypoints_file)"/>
+    <arg name="scan_topic"     value="$(arg scan_topic)"/>
+    <arg name="emcl"           value="$(arg emcl)"/>
     <arg name="suspend_file"   value="$(arg suspend_file)"/>
 
   </include>

--- a/orne_box_navigation_executor/launch/play_waypoints_nav_common.launch
+++ b/orne_box_navigation_executor/launch/play_waypoints_nav_common.launch
@@ -1,17 +1,21 @@
 <?xml version="1.0"?>
 
 <launch>
-  <arg name="robot_name"     default="alpha"/>
+  <arg name="robot_name"     default="box"/>
   <arg name="map_file"       default="$(find orne_box_navigation_executor)/maps/mymap"/>
-  <arg name="init_pos_file"  default="$(find orne_box_navigation_executor)/initial_pose_cfg/initial_pose_$(arg robot_name).yaml"/>
+  <arg name="init_pos_file"  default="$(find orne_box_navigation_executor)/initial_pose_cfg/initial_pose.yaml"/>
   <arg name="waypoints_file" default="$(find orne_box_navigation_executor)/waypoints_cfg/waypoints_$(arg robot_name).yaml"/>
   <arg name="dist_err"       default="0.8"/>
-  <arg name="suspend_file"       default="$(find orne_box_strategy)/suspend_cfg/suspend.yaml"/>
+  <arg name="suspend_file"   default="$(find orne_box_strategy)/suspend_cfg/suspend.yaml"/>
+  <arg name="scan_topic"     default="scan"/>
+  <arg name="emcl"           default="false"/>
 
   <include file="$(find orne_box_navigation_executor)/launch/nav_static_map.launch">
     <arg name="robot_name"    value="$(arg robot_name)"/>
     <arg name="map_file"      value="$(arg map_file)"/>
     <arg name="init_pos_file" value="$(arg init_pos_file)"/>
+    <arg name="scan_topic"    value="$(arg scan_topic)"/>
+    <arg name="emcl"          value="$(arg emcl)"/>
   </include>
 
   <node name="waypoints_nav" pkg="fulanghua_waypoints_nav" type="waypoints_nav" output="screen">
@@ -20,6 +24,6 @@
   </node>
 
   <node name="tsukuba_challenge_strategy" pkg="orne_box_strategy" type="tsukuba_challenge.py" output="screen">
-    <param name="filename"      value="$(arg suspend_file)"/>
+    <param name="filename" value="$(arg suspend_file)"/>
   </node>
 </launch>

--- a/orne_box_navigation_executor/param/emcl_params.yaml
+++ b/orne_box_navigation_executor/param/emcl_params.yaml
@@ -4,7 +4,6 @@ num_particles:                500
 odom_frame_id:                odom
 footprint_frame_id:           base_link
 base_frame_id:                base_link
-scan_frame_id:                hokuyo_link
 
 initial_pose_x:               0.0
 initial_pose_y:               0.0

--- a/orne_box_navigation_executor/param/emcl_params_box.yaml
+++ b/orne_box_navigation_executor/param/emcl_params_box.yaml
@@ -1,1 +1,0 @@
-invert_lidar: true

--- a/orne_box_pkgs.install
+++ b/orne_box_pkgs.install
@@ -29,5 +29,5 @@
 - git:
     uri: https://github.com/open-rdc/emcl.git
     local-name: emcl
-    version: invert_lidar
+    version: sensor_upside_down
 


### PR DESCRIPTION
emclの変更に伴いこちらも修正しました．
https://github.com/open-rdc/emcl/tree/sensor_upside_down

実行のコマンド

１）シミュレーションの起動
```
roslaunch orne_box_bringup^Crne_box_sim.launch
```

２ａ）amclを含むナビゲーションの実行
```
roslaunch orne_box_navigation_executor play_waypoints_nav_box.launch
```

２ｂ）emclを含むナビゲーションの実行
```
roslaunch orne_box_navigation_executor play_waypoints_nav_box.launch emcl:=true
```

ついでに`nav_static_map.launch`がエラーで停止するなど問題がありましたので修正しました．