### PR TITLE
Develop/update ekf

### DIFF
--- a/orne_box_bringup/launch/includes/robot_localization.launch
+++ b/orne_box_bringup/launch/includes/robot_localization.launch
@@ -26,12 +26,6 @@
                        true , true, true,
                        true, true, true,
                        false, false, false]
-        odom1: /odometry/filtered
-        odom1_config: [false, false, false,
-                       false, false, false,
-                       true , true, true,
-                       true, true, true,
-                       false, false, false]
       </rosparam>
   </node>
 </launch>

--- a/orne_box_bringup/launch/includes/robot_localization.launch
+++ b/orne_box_bringup/launch/includes/robot_localization.launch
@@ -1,0 +1,37 @@
+<?xml version="1.0"?>
+<launch>
+  <arg name="output" default="screen"/>
+  <node pkg="robot_localization" type="navsat_transform_node" name="navsat_transform_node" output="$(arg output)">
+    <remap from="imu/data" to="imu_data"/>
+    <remap from="gps/fix" to="/ublox/fix"/>
+  </node>
+  <node pkg="robot_localization" type="ekf_localization_node" name="ekf_localization_node" output="$(arg output)">
+    <rosparam>
+        publish_acceleration: true
+        print_diagnostics: true
+        two_d_mode: false
+        transform_time_offset: 0
+        transform_timeout: 0
+        sensor_timeout: 0.5
+        frequency: 20
+        twist0: /ublox/fix_velocity
+        twist0_config: [false, false, false,
+                       false, false, false,
+                       true , true, true,
+                       false, false, false,
+                       false, false, false]
+        odom0: /icart_mini/odom
+        odom0_config: [false, false, false,
+                       false, false, false,
+                       true , true, true,
+                       true, true, true,
+                       false, false, false]
+        odom1: /odometry/filtered
+        odom1_config: [false, false, false,
+                       false, false, false,
+                       true , true, true,
+                       true, true, true,
+                       false, false, false]
+      </rosparam>
+  </node>
+</launch>

--- a/orne_box_bringup/launch/orne_box.launch
+++ b/orne_box_bringup/launch/orne_box.launch
@@ -9,7 +9,7 @@
     <arg name="urg_ip"          value="192.168.0.10" />
   </include>
 
-    <include file="$(find orne_box_bringup)/launch/includes/base.launch.xml"/>
+    <include file="$(find orne_box_bringup)/launch/includes/robot_localization.launch"/>
 
   <include file="$(find orne_box_bringup)/launch/includes/rfans16.launch"/>
 

--- a/orne_box_bringup/launch/orne_box_3d_lidar.launch
+++ b/orne_box_bringup/launch/orne_box_3d_lidar.launch
@@ -9,7 +9,7 @@
     <arg name="urg_ip"          value="192.168.0.10" />
   </include>
 
-    <include file="$(find orne_box_bringup)/launch/includes/3d_base.launch.xml"/>
+  <include file="$(find orne_box_bringup)/launch/includes/robot_localization.launch"/>
 
   <include file="$(find orne_box_bringup)/launch/includes/rfans16.launch"/>
 

--- a/orne_box_navigation_executor/launch/mcl_3dl.launch
+++ b/orne_box_navigation_executor/launch/mcl_3dl.launch
@@ -41,7 +41,7 @@
 
   <node pkg="mcl_3dl" type="mcl_3dl" name="mcl_3dl" output="screen" unless="$(arg generate_test_bag)">
 	  <param name="compatible" value="1" />
-	  <remap from="odom" to="icart_mini/odom"/>
+	  <remap from="odom" to="odometry/filtered"/>
 	  <remap from="cloud" to="rfans/surestar_points"/>
 	  <remap from="imu/data" to="imu_data"/>
   </node>

--- a/orne_box_navigation_executor/launch/nav_static_map.launch
+++ b/orne_box_navigation_executor/launch/nav_static_map.launch
@@ -4,7 +4,7 @@
   <arg name="robot_name" default="alpha"/>
   <arg name="map_file"   default="$(find orne_box_navigation_executor)/maps/mymap"/>
   <arg name="init_pos_file" default="$(find orne_box_navigation_executor)/initial_pose_cfg/initial_pose.yaml"/>
-  <arg name="odom_topic" default="combined_odom"/>
+  <arg name="odom_topic" default="odometry/filtered"/>
 
   <include file="$(find orne_box_navigation_executor)/launch/move_base.launch">
     <arg name="robot_name" value="$(arg robot_name)"/>

--- a/orne_box_navigation_executor/launch/play_waypoints_nav_box_with_mcl_3dl.launch
+++ b/orne_box_navigation_executor/launch/play_waypoints_nav_box_with_mcl_3dl.launch
@@ -10,7 +10,7 @@
   <include file="$(find orne_box_navigation_executor)/launch/move_base.launch">
     <arg name="robot_name" value="$(arg robot_name)"/>
     <arg name="map_file"   value="$(arg costmap_file)"/>
-    <arg name="odom_topic" value="combined_odom"/>
+    <arg name="odom_topic" value="odometry/filtered"/>
     <arg name="cmd_vel"    value="icart_mini/cmd_vel"/>
   </include>
 


### PR DESCRIPTION
robot_localizationのekf_localizationでGNSSを参照するように変更した．

この変更には，いくつかのtf周辺の修正が含まれている．
まず，robot_pose_ekfでtfを発行せずicart_mini_driverのtfを使用しているが，move_baseにはフィルタ後の値を読ませている．
よって，累計の誤差が大きくなるにつれてmove_baseのlocal_plannerが正しく機能しないことが考えられる．
次に，フィルタが使用する情報にimuがあるが，https://github.com/open-rdc/orne-box/issues/40 と関連して正しい値が発行されていない．
このことから，imuをフィルタに使用せずにフィルタを組んだ．

最後に，icart_mini_controlにtfを発行するパラメータがあり，このlaunchの構造では上書きできないため別途で対応する必要がある．

https://github.com/open-rdc/icart/blob/ad15eeca119fa80c6bd25384254744ccb3231f45/icart_mini_control/config/icart_mini_control.yaml#L12
